### PR TITLE
feat(prom-operator): allow global baseUrl for all components

### DIFF
--- a/charts/she-runtime/CHANGELOG.md
+++ b/charts/she-runtime/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 0.0.16
+
+- prometheus Operator allow to set baseUrl for all components
+
 # 0.0.15
 
 - Removed ingressClass from prometheusOperator

--- a/charts/she-runtime/Chart.yaml
+++ b/charts/she-runtime/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: she-runtime
 description: SHE default K8s cluster toolset
 type: application
-version: 0.0.15
-appVersion: "0.0.15"
+version: 0.0.16
+appVersion: "0.0.16"

--- a/charts/she-runtime/templates/prometheus.yaml
+++ b/charts/she-runtime/templates/prometheus.yaml
@@ -15,7 +15,7 @@ spec:
       values: |
         {{- if .alertmanager.enabled }}
         alertmanager:
-          {{- if .alertmanager.ingress.enabled }}
+          {{- if .alertmanager.ingress.enabled | default .ingress.enabled }}
           ingress:
             ingressClassName: {{ .alertmanager.ingress.className }}
             enabled: true
@@ -33,14 +33,14 @@ spec:
         {{- end }}
         {{- if .grafana.enabled }}
         grafana:
-          {{- if .grafana.ingress.enabled }}
+          {{- if .grafana.ingress.enabled | default .ingress.enabled }}
           ingress:
             ingressClassName: {{ .grafana.ingress.className }}
             enabled: true
             hosts:
               - grafana.{{ .grafana.ingress.baseUrl | default .ingress.baseUrl }}
             tls:
-              - host
+              - hosts:
                  - grafana.{{ .grafana.ingress.baseUrl | default .ingress.baseUrl }}
             annotations:
               nginx.ingress.kubernetes.io/force-ssl-redirect: 'true'
@@ -133,7 +133,7 @@ spec:
             serviceMonitorSelector:
               matchExpressions:
                 - {key: release, operator: In, values: [{{.prometheus.serviceMonitorSelectors}}]}
-          {{- if .prometheus.ingress.enabled }}
+          {{- if .prometheus.ingress.enabled | default .ingress.enabled }}
           ingress:
             ingressClassName: {{ .prometheus.ingress.className }}
             enabled: true

--- a/charts/she-runtime/templates/prometheus.yaml
+++ b/charts/she-runtime/templates/prometheus.yaml
@@ -20,10 +20,10 @@ spec:
             ingressClassName: {{ .alertmanager.ingress.className }}
             enabled: true
             hosts:
-              - alertmanager.{{ .alertmanager.ingress.baseUrl }}
+              - alertmanager.{{ .alertmanager.ingress.baseUrl | default .ingress.baseUrl }}
             tls:
               - hosts:
-                 - alertmanager.{{ .alertmanager.ingress.baseUrl }}
+                 - alertmanager.{{ .alertmanager.ingress.baseUrl | default .ingress.baseUrl }}
             annotations:
               nginx.ingress.kubernetes.io/force-ssl-redirect: 'true'
               nginx.ingress.kubernetes.io/backend-protocol: HTTP
@@ -38,10 +38,10 @@ spec:
             ingressClassName: {{ .grafana.ingress.className }}
             enabled: true
             hosts:
-              - grafana.{{ .grafana.ingress.baseUrl }}
+              - grafana.{{ .grafana.ingress.baseUrl | default .ingress.baseUrl }}
             tls:
-              - hosts:
-                 - grafana.{{ .grafana.ingress.baseUrl }}
+              - host
+                 - grafana.{{ .grafana.ingress.baseUrl | default .ingress.baseUrl }}
             annotations:
               nginx.ingress.kubernetes.io/force-ssl-redirect: 'true'
               nginx.ingress.kubernetes.io/backend-protocol: HTTP
@@ -60,8 +60,8 @@ spec:
             grafana_net:
               url: https://grafana.net
             server:
-              domain: "grafana.{{ .grafana.ingress.baseUrl }}"
-              root_url: https://grafana.{{ .grafana.ingress.baseUrl }}
+              domain: "grafana.{{ .grafana.ingress.baseUrl | default .ingress.baseUrl }}"
+              root_url: https://grafana.{{ .grafana.ingress.baseUrl | default .ingress.baseUrl }}
               router_logging: true
               enforce_domain: true
             auth:
@@ -138,10 +138,10 @@ spec:
             ingressClassName: {{ .prometheus.ingress.className }}
             enabled: true
             hosts:
-              - prometheus.{{ .prometheus.ingress.baseUrl }}
+              - prometheus.{{ .prometheus.ingress.baseUrl | default .ingress.baseUrl }}
             tls:
               - hosts:
-                 - prometheus.{{ .prometheus.ingress.baseUrl }}
+                 - prometheus.{{ .prometheus.ingress.baseUrl | default .ingress.baseUrl }}
             annotations:
               nginx.ingress.kubernetes.io/force-ssl-redirect: 'true'
               nginx.ingress.kubernetes.io/backend-protocol: HTTP

--- a/charts/she-runtime/values.yaml
+++ b/charts/she-runtime/values.yaml
@@ -47,17 +47,18 @@ prometheusOperator:
   name: prom-operator
   enabled: true
   ingress:
+    enabled: true
     baseUrl: my.domain
   alertmanager:
     enabled: true
-    ingress:
-      enabled: true
-      baseUrl: my.domain
+    # ingress:
+      # enabled: true
+      # baseUrl: my.domain
   grafana:
     enabled: true
-    ingress:
-      enabled: true
-      baseUrl: my.domain
+    # ingress:
+      # enabled: true
+      # baseUrl: my.domain
   prometheus:
     enabled: true
     crunchyPostgresExporter:
@@ -65,9 +66,9 @@ prometheusOperator:
     serviceMonitorSelectors:
       matchLabels:
         prometheus: she
-    ingress:
-      enabled: true
-      baseUrl: my.domain
+    # ingress:
+      # enabled: true
+      # baseUrl: my.domain
   source:
     repoURL: https://prometheus-community.github.io/helm-charts
     targetRevision: 44.3.0

--- a/charts/she-runtime/values.yaml
+++ b/charts/she-runtime/values.yaml
@@ -46,6 +46,8 @@ prometheusOperator:
   namespace: monitoring
   name: prom-operator
   enabled: true
+  ingress:
+    baseUrl: my.domain
   alertmanager:
     enabled: true
     ingress:


### PR DESCRIPTION
# Change

- Allow a global `baseUrl` for all kube-prometheus-stack components