### PR TITLE
Rename ingressclass of public ingress controller to public

### DIFF
--- a/charts/she-runtime/CHANGELOG.md
+++ b/charts/she-runtime/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 0.0.19
+
+- Rename ingressClass of the public ingress controller from `nginx` to `public` to make it more obvious that things are made accessible by using this class.
+
 # 0.0.18
 
 - Rewrite logic for serviceMonitorSelectors

--- a/charts/she-runtime/Chart.yaml
+++ b/charts/she-runtime/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: she-runtime
 description: SHE default K8s cluster toolset
 type: application
-version: 0.0.18
-appVersion: "0.0.18"
+version: 0.0.19
+appVersion: "0.0.19"

--- a/charts/she-runtime/values.yaml
+++ b/charts/she-runtime/values.yaml
@@ -109,6 +109,8 @@ publicIngressController:
       parameters:
         - name: controller.ingressClass
           value: public
+        - name: controller.ingressClassResource.name
+          value: public
         - name: controller.ingressClassResource.controllerValue
           value: k8s.io/ingress-nginx-public
 

--- a/charts/she-runtime/values.yaml
+++ b/charts/she-runtime/values.yaml
@@ -108,7 +108,7 @@ publicIngressController:
     helm:
       parameters:
         - name: controller.ingressClass
-          value: nginx-internal
+          value: public
         - name: controller.ingressClassResource.controllerValue
           value: k8s.io/ingress-nginx-public
 

--- a/charts/she-runtime/values.yaml
+++ b/charts/she-runtime/values.yaml
@@ -107,6 +107,8 @@ publicIngressController:
     chart: ingress-nginx
     helm:
       parameters:
+        - name: controller.ingressClass
+          value: nginx-internal
         - name: controller.ingressClassResource.controllerValue
           value: k8s.io/ingress-nginx-public
 


### PR DESCRIPTION
# Changes

This change renames the ingress class of the public ingress controller to "public". This way someone has to make ingress resources explicitly accessible