### PR TITLE
Use kubernetes.she.net/prometheus-instance label for detection

### DIFF
--- a/charts/she-runtime/CHANGELOG.md
+++ b/charts/she-runtime/CHANGELOG.md
@@ -1,3 +1,8 @@
+# 0.0.53
+
+- nstead of detecting ServiceMonitors, PodMonitors and PrometheusRules by the release label
+  we use the kubernetes.she.net/prometheus-instance label now
+
 # 0.0.52
 - enable sealed secrets skipRecreate by default
 

--- a/charts/she-runtime/Chart.yaml
+++ b/charts/she-runtime/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: she-runtime
 description: SHE default K8s cluster toolset
 type: application
-version: 0.0.52
-appVersion: "0.0.52"
+version: 0.0.53
+appVersion: "0.0.53"

--- a/charts/she-runtime/templates/prometheus.yaml
+++ b/charts/she-runtime/templates/prometheus.yaml
@@ -14,7 +14,7 @@ spec:
     helm:
       values: |
         commonLabels:
-          {{- dict "kubernetes.she.net/prometheus-instance" "default" | merge (.commonLabels | default dict) | toYaml | nindent 10 }} 
+          {{- dict "kubernetes.she.net/prometheus-instance" "default" | merge .commonLabels | toYaml | nindent 10 }} 
         {{- with .coreDns }}
         coreDns:
           {{- toYaml . | nindent 10 }}

--- a/charts/she-runtime/templates/prometheus.yaml
+++ b/charts/she-runtime/templates/prometheus.yaml
@@ -220,10 +220,20 @@ spec:
                     target_label: schemaname
                     replacement: '$1'
               {{- end }}
-            {{- if .prometheus.serviceMonitorSelectors }}
             serviceMonitorSelector:
+            {{- if .prometheus.serviceMonitorSelectors }}
               {{- toYaml .prometheus.serviceMonitorSelectors | nindent 14 }}
-            {{- end }}              
+            {- else }}
+              matchLabels:
+                kubernetes.she.net/prometheus-instance: default
+            {{- end }} 
+            podMonitorSelector:
+            {{- if .prometheus.podMonitorSelectors }}
+              {{- toYaml .prometheus.podMonitorSelectors | nindent 14 }}
+            {- else }}
+              matchLabels:
+                kubernetes.she.net/prometheus-instance: default
+            {{- end }} 
             {{- if .prometheus.additionalAlertManagerConfigs }}
             additionalAlertManagerConfigs:
               {{- toYaml .prometheus.additionalAlertManagerConfigs | nindent 14 }}

--- a/charts/she-runtime/templates/prometheus.yaml
+++ b/charts/she-runtime/templates/prometheus.yaml
@@ -13,6 +13,8 @@ spec:
     chart: {{ .source.chart }}
     helm:
       values: |
+        commonLabels:
+          {{- dict "kubernetes.she.net/prometheus-instance" "default" | merge (.commonLabels | default dict) | toYaml | nindent 10 }} 
         {{- with .coreDns }}
         coreDns:
           {{- toYaml . | nindent 10 }}

--- a/charts/she-runtime/templates/prometheus.yaml
+++ b/charts/she-runtime/templates/prometheus.yaml
@@ -236,6 +236,13 @@ spec:
               matchLabels:
                 kubernetes.she.net/prometheus-instance: default
             {{- end }} 
+            ruleSelector:
+            {{- if .prometheus.ruleSelectors }}
+              {{- toYaml .prometheus.ruleSelectors | nindent 14 }}
+            {- else }}
+              matchLabels:
+                kubernetes.she.net/prometheus-instance: default
+            {{- end }} 
             {{- if .prometheus.additionalAlertManagerConfigs }}
             additionalAlertManagerConfigs:
               {{- toYaml .prometheus.additionalAlertManagerConfigs | nindent 14 }}

--- a/charts/she-runtime/values.yaml
+++ b/charts/she-runtime/values.yaml
@@ -109,6 +109,9 @@ prometheusOperator:
 #    podMonitorSelectors:
 #      matchLabels:
 #        kubernetes.she.net/prometheus-instance: default
+#    ruleSelectors:
+#      matchLabels:
+#        kubernetes.she.net/prometheus-instance: default
     ingress: {}
     # ingress:
       # enabled: true

--- a/charts/she-runtime/values.yaml
+++ b/charts/she-runtime/values.yaml
@@ -99,6 +99,8 @@ prometheusOperator:
     #   defaultMode: 0440
   prometheus:
     enabled: true
+    commonLabels: {}
+#      labelKey: labelValue
     crunchyPostgresExporter:
       enabled: true
 #    serviceMonitorSelectors:

--- a/charts/she-runtime/values.yaml
+++ b/charts/she-runtime/values.yaml
@@ -103,7 +103,10 @@ prometheusOperator:
       enabled: true
 #    serviceMonitorSelectors:
 #      matchLabels:
-#        prometheus: she
+#        kubernetes.she.net/prometheus-instance: default
+#    podMonitorSelectors:
+#      matchLabels:
+#        kubernetes.she.net/prometheus-instance: default
     ingress: {}
     # ingress:
       # enabled: true


### PR DESCRIPTION
# Changes

Instead of detecting `ServiceMonitors`, `PodMonitors` and `PrometheusRules` by the release label we use a consistent SHE labels unless it is overrriden