### PR TITLE
feat(ingress-internal): add http2 support to internal ingress 

### DIFF
--- a/charts/she-runtime/CHANGELOG.md
+++ b/charts/she-runtime/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 0.0.84
+
+- Enable http2 support on internal ingress
+
 # 0.0.83
 # Update kube-prometheus-stack
 

--- a/charts/she-runtime/Chart.yaml
+++ b/charts/she-runtime/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: she-runtime
 description: SHE default K8s cluster toolset
 type: application
-version: 0.0.84
-appVersion: "0.0.84"
+version: 0.0.85
+appVersion: "0.0.85"

--- a/charts/she-runtime/Chart.yaml
+++ b/charts/she-runtime/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: she-runtime
 description: SHE default K8s cluster toolset
 type: application
-version: 0.0.83
-appVersion: "0.0.83"
+version: 0.0.84
+appVersion: "0.0.84"

--- a/charts/she-runtime/README.md
+++ b/charts/she-runtime/README.md
@@ -1,6 +1,6 @@
 # she-runtime
 
-![Version: 0.0.84](https://img.shields.io/badge/Version-0.0.84-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.0.84](https://img.shields.io/badge/AppVersion-0.0.84-informational?style=flat-square)
+![Version: 0.0.85](https://img.shields.io/badge/Version-0.0.85-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.0.85](https://img.shields.io/badge/AppVersion-0.0.85-informational?style=flat-square)
 
 SHE default K8s cluster toolset
 

--- a/charts/she-runtime/README.md
+++ b/charts/she-runtime/README.md
@@ -1,6 +1,6 @@
 # she-runtime
 
-![Version: 0.0.83](https://img.shields.io/badge/Version-0.0.83-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.0.83](https://img.shields.io/badge/AppVersion-0.0.83-informational?style=flat-square)
+![Version: 0.0.84](https://img.shields.io/badge/Version-0.0.84-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.0.84](https://img.shields.io/badge/AppVersion-0.0.84-informational?style=flat-square)
 
 SHE default K8s cluster toolset
 

--- a/charts/she-runtime/README.md
+++ b/charts/she-runtime/README.md
@@ -52,6 +52,8 @@ SHE default K8s cluster toolset
 | internalIngressController.source.helm.parameters[2].value | string | `"nginx-internal"` |  |
 | internalIngressController.source.helm.parameters[3].name | string | `"controller.ingressClassResource.default"` |  |
 | internalIngressController.source.helm.parameters[3].value | string | `"true"` |  |
+| internalIngressController.source.helm.parameters[4].name | string | `"controller.config.use-http2"` |  |
+| internalIngressController.source.helm.parameters[4].value | string | `"true"` |  |
 | internalIngressController.source.repoURL | string | `"https://kubernetes.github.io/ingress-nginx"` |  |
 | internalIngressController.source.targetRevision | string | `"4.8.3"` |  |
 | kyverno.enabled | bool | `false` |  |

--- a/charts/she-runtime/values.yaml
+++ b/charts/she-runtime/values.yaml
@@ -159,6 +159,8 @@ internalIngressController:
           value: nginx-internal
         - name: controller.ingressClassResource.default
           value: 'true'
+        - name: controller.config.use-http2
+          value: 'true'
 publicIngressController:
   namespace: public-ingress
   name: public-ingress


### PR DESCRIPTION
# Change 

- enable http2 support on internal ingress so that argocd cli works out of the box