### PR TITLE
Updating the opensearch operator version to 2.6.0

### DIFF
--- a/charts/she-runtime/README.md
+++ b/charts/she-runtime/README.md
@@ -93,7 +93,7 @@ SHE default K8s cluster toolset
 | opensearchOperator.namespace | string | `"opensearch-operator"` |  |
 | opensearchOperator.source.chart | string | `"opensearch-operator"` |  |
 | opensearchOperator.source.repoURL | string | `"https://opensearch-project.github.io/opensearch-k8s-operator/"` |  |
-| opensearchOperator.source.targetRevision | string | `"2.5.1"` |  |
+| opensearchOperator.source.targetRevision | string | `"2.6.0"` |  |
 | postgresOperator.enabled | bool | `true` |  |
 | postgresOperator.name | string | `"postgres-operator"` |  |
 | postgresOperator.namespace | string | `"postgres-operator"` |  |

--- a/charts/she-runtime/values.yaml
+++ b/charts/she-runtime/values.yaml
@@ -356,7 +356,7 @@ opensearchOperator:
   source:
     repoURL: https://opensearch-project.github.io/opensearch-k8s-operator/
     chart: opensearch-operator
-    targetRevision: 2.5.1
+    targetRevision: 2.6.0
 
 taintController:
   enabled: false


### PR DESCRIPTION
Opensearch version 2.6.0 includes data streams capabilities so bumping the version from 2.5.1 to keep it up to date and also add the latest features. 