### PR TITLE
Enabling opensearch operator

### DIFF
--- a/charts/she-runtime/CHANGELOG.md
+++ b/charts/she-runtime/CHANGELOG.md
@@ -1,3 +1,6 @@
+# 1.3.3
+- Enabled Opensearch Operator
+
 # 1.3.2
 - Bump opensearch Controller version
 

--- a/charts/she-runtime/Chart.yaml
+++ b/charts/she-runtime/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: she-runtime
 description: SHE default K8s cluster toolset
 type: application
-version: 1.3.2
-appVersion: "1.3.2"
+version: 1.3.3
+appVersion: "1.3.3"

--- a/charts/she-runtime/README.md
+++ b/charts/she-runtime/README.md
@@ -1,6 +1,6 @@
 # she-runtime
 
-![Version: 1.3.2](https://img.shields.io/badge/Version-1.3.2-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.3.2](https://img.shields.io/badge/AppVersion-1.3.2-informational?style=flat-square)
+![Version: 1.3.3](https://img.shields.io/badge/Version-1.3.3-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.3.3](https://img.shields.io/badge/AppVersion-1.3.3-informational?style=flat-square)
 
 SHE default K8s cluster toolset
 
@@ -88,7 +88,7 @@ SHE default K8s cluster toolset
 | minioOperator.source.chart | string | `"operator"` |  |
 | minioOperator.source.repoURL | string | `"https://operator.min.io"` |  |
 | minioOperator.source.targetRevision | string | `"5.0.14"` |  |
-| opensearchOperator.enabled | bool | `false` |  |
+| opensearchOperator.enabled | bool | `true` |  |
 | opensearchOperator.name | string | `"opensearch-operator"` |  |
 | opensearchOperator.namespace | string | `"opensearch-operator"` |  |
 | opensearchOperator.source.chart | string | `"opensearch-operator"` |  |

--- a/charts/she-runtime/values.yaml
+++ b/charts/she-runtime/values.yaml
@@ -350,7 +350,7 @@ minioOperator:
     #           value: monitoring
 
 opensearchOperator:
-  enabled: false
+  enabled: true
   namespace: opensearch-operator
   name: opensearch-operator
   source:


### PR DESCRIPTION
Enabling Opensearch operator from `she-runtime` as part of the Opensearch installation in S/H/E environment. 
Bumping up `she-runtime` version.