### PR TITLE
Adding default namespace for opensearch templates

### DIFF
--- a/charts/logging-opensearch/Chart.yaml
+++ b/charts/logging-opensearch/Chart.yaml
@@ -8,4 +8,4 @@ dependencies:
     repository: https://fluent.github.io/helm-charts
     version: 0.46.4
 appVersion: "1.0.4"
-version: 1.0.4
+version: 1.0.5

--- a/charts/logging-opensearch/templates/indextemplate-access.yaml
+++ b/charts/logging-opensearch/templates/indextemplate-access.yaml
@@ -3,7 +3,7 @@ apiVersion: opensearch.opster.io/v1
 kind: OpensearchIndexTemplate
 metadata:
   name: {{ include "logging-opensearch.name" . }}-access
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ .Release.Namespace | default "logging" }}
   labels:
     {{- include "logging-opensearch.labels" . | nindent 4 }}
 spec:

--- a/charts/logging-opensearch/templates/indextemplate-additional.yaml
+++ b/charts/logging-opensearch/templates/indextemplate-additional.yaml
@@ -3,7 +3,7 @@ apiVersion: opensearch.opster.io/v1
 kind: OpensearchIndexTemplate
 metadata:
   name: {{ include "logging-opensearch.name" $ }}-{{ $template.name }}
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ .Release.Namespace | default "logging" }}
   labels:
     {{- include "logging-opensearch.labels" $ | nindent 4 }}
 spec:

--- a/charts/logging-opensearch/templates/indextemplate-audit.yaml
+++ b/charts/logging-opensearch/templates/indextemplate-audit.yaml
@@ -3,7 +3,7 @@ apiVersion: opensearch.opster.io/v1
 kind: OpensearchIndexTemplate
 metadata:
   name: {{ include "logging-opensearch.name" . }}-audit
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ .Release.Namespace | default "logging" }}
   labels:
     {{- include "logging-opensearch.labels" . | nindent 4 }}
 spec:

--- a/charts/logging-opensearch/templates/indextemplate-container.yaml
+++ b/charts/logging-opensearch/templates/indextemplate-container.yaml
@@ -3,7 +3,7 @@ apiVersion: opensearch.opster.io/v1
 kind: OpensearchIndexTemplate
 metadata:
   name: {{ include "logging-opensearch.name" . }}-container
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ .Release.Namespace | default "logging" }}
   labels:
     {{- include "logging-opensearch.labels" . | nindent 4 }}
 spec:

--- a/charts/logging-opensearch/templates/opensearch-cluster.yaml
+++ b/charts/logging-opensearch/templates/opensearch-cluster.yaml
@@ -3,7 +3,7 @@ apiVersion: opensearch.opster.io/v1
 kind: OpenSearchCluster
 metadata:
   name: {{ include "logging-opensearch.opensearchName" . }}
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ .Release.Namespace | default "logging" }}
   labels:
     {{- include "logging-opensearch.labels" . | nindent 4 }}
 spec:

--- a/charts/logging-opensearch/templates/opensearch-ingress.yaml
+++ b/charts/logging-opensearch/templates/opensearch-ingress.yaml
@@ -15,7 +15,7 @@ apiVersion: extensions/v1beta1
 kind: Ingress
 metadata:
   name: {{ $name }}
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ .Release.Namespace | default "logging" }}
   labels:
     {{- include "logging-opensearch.labels" . | nindent 4 }}
   {{- with .Values.opensearch.ingress.annotations }}

--- a/charts/logging-opensearch/templates/opensearch-rolebindings.yaml
+++ b/charts/logging-opensearch/templates/opensearch-rolebindings.yaml
@@ -11,7 +11,7 @@ apiVersion: opensearch.opster.io/v1
 kind: OpensearchUserRoleBinding
 metadata:
   name: {{ $role.name }}
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ .Release.Namespace | default "logging" }}
   labels:
     {{- include "logging-opensearch.labels" $ | nindent 4 }}
 spec:

--- a/charts/logging-opensearch/templates/opensearch-roles.yaml
+++ b/charts/logging-opensearch/templates/opensearch-roles.yaml
@@ -3,7 +3,7 @@ apiVersion: opensearch.opster.io/v1
 kind: OpensearchRole
 metadata:
   name: {{ $role.name }}
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ .Release.Namespace | default "logging" }}
   labels:
     {{- include "logging-opensearch.labels" $ | nindent 4 }}
 spec:

--- a/charts/logging-opensearch/templates/opensearch-users.yaml
+++ b/charts/logging-opensearch/templates/opensearch-users.yaml
@@ -3,7 +3,7 @@ apiVersion: opensearch.opster.io/v1
 kind: OpensearchUser
 metadata:
   name: {{ $user.name }}
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ .Release.Namespace | default "logging" }}
   labels:
     {{- include "logging-opensearch.labels" $ | nindent 4 }}
 spec:


### PR DESCRIPTION
Adding default "logging" namespace for opensearch templates.