### PR TITLE
Disabling dynamic mapping for kubernetes labels

### DIFF
--- a/charts/logging-opensearch/Chart.yaml
+++ b/charts/logging-opensearch/Chart.yaml
@@ -7,5 +7,5 @@ dependencies:
     alias: fluentbit
     repository: https://fluent.github.io/helm-charts
     version: 0.46.7
-appVersion: "1.1.0"
-version: 1.1.0
+appVersion: "1.1.1"
+version: 1.1.1

--- a/charts/logging-opensearch/templates/indextemplate-container.yaml
+++ b/charts/logging-opensearch/templates/indextemplate-container.yaml
@@ -49,7 +49,7 @@ spec:
                 "ignore_above": 256
               },
               "labels": {
-                "dynamic": "true",
+                "dynamic": "false",
                 "type": "object"
               },
               "namespace_name": {


### PR DESCRIPTION
Disabling dynamic mapping for kubernetes labels