### PR TITLE
Adding lua script for k8s labels dot removal

### DIFF
--- a/charts/logging-opensearch/values.yaml
+++ b/charts/logging-opensearch/values.yaml
@@ -20,6 +20,45 @@ fluentbit:
     labelKey: grafana_dashboard
     labelValue: 1
     namespace: monitoring
+  luaScripts:
+    kubernetes.lua: |
+      function cb_convert_labels(tag, timestamp, record)
+        if record["autodiscover.event"]["kubernetes"] == nil then
+          return 0, 0, 0
+        end
+
+        for k, v in pairs(record["autodiscover.event"]["kubernetes"]["labels"])
+        do
+          if (v ~= nil and type(v) ~= "table") then
+            if k == "app" then
+              k = "app_"  -- Rename 'app' to 'app_'
+            end
+            record["autodiscover.event"]["kubernetes"]["labels"][k] = {[k .. "Name"] = v}
+          end
+        end
+        return 2, timestamp, record
+      end
+      function dedot(tag, timestamp, record)
+          if record["kubernetes"] == nil then
+              return 0, 0, 0
+          end
+          dedot_keys(record["kubernetes"]["annotations"])
+          dedot_keys(record["kubernetes"]["labels"])
+          return 1, timestamp, record
+      end
+
+      function dedot_keys(map)
+          if map == nil then
+              return
+          end
+          for k, v in pairs(map) do
+              dedotted = string.gsub(k, "%.", "_")
+              if k ~= dedotted then
+                  map[dedotted] = v
+                  map[k] = nil
+              end
+          end
+      end
   config:
     inputs: |
       [INPUT]
@@ -53,6 +92,12 @@ fluentbit:
           Buffer_Max_Size 64m
 
     filters: |
+      [FILTER]
+          Name    lua
+          Match   kube.*
+          script  /fluent-bit/scripts/kubernetes.lua
+          call    dedot
+
       [FILTER]
           Name kubernetes
           Match kube.*
@@ -88,6 +133,7 @@ fluentbit:
           Host opensearch-cluster.logging.svc
           Port 9200
           Index container-%Y.%m
+          Replace_Dots On
           Retry_Limit 3
           Suppress_Type_Name On
           tls On
@@ -104,6 +150,7 @@ fluentbit:
           Host opensearch-cluster.logging.svc
           Port 9200
           Index audit-%Y.%m
+          Replace_Dots On
           Retry_Limit 3
           Suppress_Type_Name On
           tls On
@@ -119,6 +166,7 @@ fluentbit:
           Host opensearch-cluster.logging.svc
           Port 9200
           Index access-logs-%Y.%m
+          Replace_Dots On
           Retry_Limit 3
           Suppress_Type_Name On
           tls On


### PR DESCRIPTION
Adding lua functions to the fluentbit config to filter the kubenetes logs and replace dots for app labels. 