### PR TITLE
Adding parser in flunetbit config for plaintext logs

### DIFF
--- a/charts/logging-opensearch/CHANGELOG.md
+++ b/charts/logging-opensearch/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 1.1.3
+- New parser for processing plaintext logs from Postgresql
+- Re-enabled dynamic mapping for Kubernetes labels
+
 # 1.1.2
 - fixed version for release
 

--- a/charts/logging-opensearch/Chart.yaml
+++ b/charts/logging-opensearch/Chart.yaml
@@ -7,5 +7,5 @@ dependencies:
     alias: fluentbit
     repository: https://fluent.github.io/helm-charts
     version: 0.46.7
-appVersion: "1.1.2"
-version: 1.1.2
+appVersion: "1.1.3"
+version: 1.1.3

--- a/charts/logging-opensearch/README.md
+++ b/charts/logging-opensearch/README.md
@@ -1,6 +1,6 @@
 # logging-opensearch
 
-![Version: 1.1.2](https://img.shields.io/badge/Version-1.1.2-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.1.2](https://img.shields.io/badge/AppVersion-1.1.2-informational?style=flat-square)
+![Version: 1.1.3](https://img.shields.io/badge/Version-1.1.3-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.1.3](https://img.shields.io/badge/AppVersion-1.1.3-informational?style=flat-square)
 
 A Helm chart which deploys a Opensearch cluster manifests, its configuation and fluent bit
 

--- a/charts/logging-opensearch/templates/indextemplate-container.yaml
+++ b/charts/logging-opensearch/templates/indextemplate-container.yaml
@@ -49,7 +49,7 @@ spec:
                 "ignore_above": 256
               },
               "labels": {
-                "dynamic": "false",
+                "dynamic": "true",
                 "type": "object"
               },
               "namespace_name": {

--- a/charts/logging-opensearch/values.yaml
+++ b/charts/logging-opensearch/values.yaml
@@ -52,6 +52,15 @@ fluentbit:
           Buffer_Chunk_Size 15m
           Buffer_Max_Size 64m
 
+      [INPUT]
+          Name tail
+          Path /var/log/postgresql/*.log*
+          Tag plaintext.*
+          Parser generic_plaintext
+          Mem_Buf_Limit 5m
+          Buffer_Chunk_Size 15m
+          Buffer_Max_Size 64m
+
     filters: |
       [FILTER]
           Name kubernetes
@@ -80,6 +89,14 @@ fluentbit:
           Name grep
           Match ingress-nginx.*
           Exclude log ^.+$
+
+      [FILTER]
+          Name kubernetes
+          Match plaintext.*
+          Merge_Log On
+          Keep_Log Off
+          K8S-Logging.Parser On
+          K8S-Logging.Exclude On
 
     outputs: |
       [OUTPUT]
@@ -128,6 +145,21 @@ fluentbit:
           Trace_Error On
           Buffer_Size 2MB
 
+      [OUTPUT]
+          Name opensearch
+          Match plaintext.*
+          Host opensearch-cluster.logging.svc
+          Port 9200
+          Index container-%Y.%m
+          Retry_Limit 3
+          Suppress_Type_Name On
+          tls On
+          tls.verify Off
+          HTTP_User fluentbit
+          HTTP_Passwd ${password}
+          Trace_Error On
+          Buffer_Size 2MB
+
     customParsers: |
       [PARSER]
           Name docker_no_time
@@ -140,6 +172,13 @@ fluentbit:
           Name        accesslogs
           Format      regex
           Regex       ^(?<remote_addr>[^ ]+) - (?<user_identity>[^ ]+) \[(?<timestamp>[^\]]+)\] \"(?<method>\S+)(?: +(?<request_uri>\S+)(?: +(?<protocol>\S+))?)?\" (?<status>\d+) (?<bytes_sent>\d+) \"(?<referrer>[^"]*)\" \"(?<user_agent>[^"]*)\" (?<request_length>[^ ]*) (?<request_time>[^ ]*) \[(?<proxy_upstream_name>[^ ]*)\] \[(?<proxy_alternative_upstream_name>[^ ]*)\] (?<upstream_addr>[^ ]*) (?<upstream_response_length>[^ ]*) (?<upstream_response_time>[^ ]*) (?<upstream_status>[^ ]*) (?<reg_id>[^ ]*).*$
+
+      [PARSER]
+          Name generic_plaintext
+          Format regex
+          Regex ^(?<timestamp>\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2},\d{3}) (?<log_level>\w+): (?<message>.*)$
+          Time_Key timestamp
+          Time_Format %Y-%m-%d %H:%M:%S,%L
 
   tolerations:
     - operator: Exists


### PR DESCRIPTION
Adding new parser for processing plaintext logs (at the moment coming from Postgres) and re-enabling the kubernetes labels dynamic mapping.