### PR TITLE
Adjusting the backend kibana role to fix fluentbit permissions

### DIFF
--- a/charts/logging-opensearch/CHANGELOG.md
+++ b/charts/logging-opensearch/CHANGELOG.md
@@ -1,3 +1,6 @@
+# 1.1.3
+- fixed kibana backend role reference
+
 # 1.1.2
 - fixed version for release
 

--- a/charts/logging-opensearch/Chart.yaml
+++ b/charts/logging-opensearch/Chart.yaml
@@ -7,5 +7,5 @@ dependencies:
     alias: fluentbit
     repository: https://fluent.github.io/helm-charts
     version: 0.46.7
-appVersion: "1.1.2"
-version: 1.1.2
+appVersion: "1.1.3"
+version: 1.1.3

--- a/charts/logging-opensearch/README.md
+++ b/charts/logging-opensearch/README.md
@@ -1,6 +1,6 @@
 # logging-opensearch
 
-![Version: 1.1.2](https://img.shields.io/badge/Version-1.1.2-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.1.2](https://img.shields.io/badge/AppVersion-1.1.2-informational?style=flat-square)
+![Version: 1.1.3](https://img.shields.io/badge/Version-1.1.3-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.1.3](https://img.shields.io/badge/AppVersion-1.1.3-informational?style=flat-square)
 
 A Helm chart which deploys a Opensearch cluster manifests, its configuation and fluent bit
 
@@ -81,7 +81,7 @@ A Helm chart which deploys a Opensearch cluster manifests, its configuation and 
 | opensearch.settings.security.config.securityConfigSecret.name | string | `"securityconfig-secret"` |  |
 | opensearch.settings.security.tls.http.generate | bool | `true` |  |
 | opensearch.settings.security.tls.transport.generate | bool | `true` |  |
-| opensearch.users[0].backendRoles[0] | string | `"kibanauser"` |  |
+| opensearch.users[0].backendRoles[0] | string | `"kibana_user"` |  |
 | opensearch.users[0].name | string | `"fluentbit"` |  |
 | opensearch.users[0].passwordFrom.key | string | `"password"` |  |
 | opensearch.users[0].passwordFrom.name | string | `"fluentbit-password"` |  |

--- a/charts/logging-opensearch/values.yaml
+++ b/charts/logging-opensearch/values.yaml
@@ -180,7 +180,7 @@ opensearch:
         name: fluentbit-password
         key: password
       backendRoles:
-        - kibanauser
+        - kibana_user
       roles:
         - fluentbit
 


### PR DESCRIPTION
While going over the Fluentbit user permissions issues the kibanauser backend role does not exist so the Fluentbit failed to push logs to Opensearch.