### PR TITLE
Limiting the disk size alerts to pgdata mount point

### DIFF
--- a/charts/monitoring-rules/CHANGELOG.md
+++ b/charts/monitoring-rules/CHANGELOG.md
@@ -1,3 +1,6 @@
+# 3.2.1
+- Limited DiskFillPredict and PGDiskSize alerts to pgdata mount point
+
 # 3.2.0
 - Limited backup alerts for postgres to non-standby clusters
 

--- a/charts/monitoring-rules/Chart.yaml
+++ b/charts/monitoring-rules/Chart.yaml
@@ -13,9 +13,9 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 3.2.0
+version: 3.2.1
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "3.2.0"
+appVersion: "3.2.1"

--- a/charts/monitoring-rules/README.md
+++ b/charts/monitoring-rules/README.md
@@ -1,6 +1,6 @@
 # monitoring-rules
 
-![Version: 3.2.0](https://img.shields.io/badge/Version-3.2.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 3.2.0](https://img.shields.io/badge/AppVersion-3.2.0-informational?style=flat-square)
+![Version: 3.2.1](https://img.shields.io/badge/Version-3.2.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 3.2.1](https://img.shields.io/badge/AppVersion-3.2.1-informational?style=flat-square)
 
 A curated set of prometheus alerting rules for Kubernetes.
 

--- a/charts/monitoring-rules/templates/prometheusrule-postgres.yaml
+++ b/charts/monitoring-rules/templates/prometheusrule-postgres.yaml
@@ -59,7 +59,7 @@ spec:
     {{- end }}
     {{- if not ( .Values.postgres.disabledRules.diskFillPredict | default false ) }}
     - alert: DiskFillPredict
-      expr: predict_linear(ccp_nodemx_data_disk_available_bytes{mount_point!~"tmpfs"}[1h], 24 * 3600) < 0 and 100 * ((ccp_nodemx_data_disk_total_bytes - ccp_nodemx_data_disk_available_bytes) / ccp_nodemx_data_disk_total_bytes) > 70
+      expr: predict_linear(ccp_nodemx_data_disk_available_bytes{mount_point!~"tmpfs"}[1h], 24 * 3600) < 0 and 100 * ((ccp_nodemx_data_disk_total_bytes{mount_point="/pgdata"} - ccp_nodemx_data_disk_available_bytes{mount_point="/pgdata"}) / ccp_nodemx_data_disk_total_bytes{mount_point="/pgdata"}) > 70
       for: 5m
       labels:
         service: postgresql
@@ -80,7 +80,7 @@ spec:
     {{- end }}
     {{- if not ( .Values.postgres.disabledRules.pgDiskSize | default false ) }}
     - alert: PGDiskSize
-      expr: 100 * ((ccp_nodemx_data_disk_total_bytes - ccp_nodemx_data_disk_available_bytes) / ccp_nodemx_data_disk_total_bytes) > 75
+      expr: 100 * ((ccp_nodemx_data_disk_total_bytes{mount_point="/pgdata"} - ccp_nodemx_data_disk_available_bytes{mount_point="/pgdata"}) / ccp_nodemx_data_disk_total_bytes{mount_point="/pgdata"}) > 75
       for: 60s
       labels:
         service: postgresql


### PR DESCRIPTION
DiskFillPrediction and PGDiskSize alerts are not targeting the pgdata mount point and therefore are creating alerts that are confusing.