### PR TITLE
feat(opensearch-operator): bump version to v2.6.1

### DIFF
--- a/charts/she-runtime/CHANGELOG.md
+++ b/charts/she-runtime/CHANGELOG.md
@@ -1,3 +1,6 @@
+# 1.4.2
+- Bump opensearch-operator version to v2.6.1
+
 # 1.4.1
 - Remove obsolete grafanaDashboard section since dashboards became part of the monitoring rules charts
 

--- a/charts/she-runtime/Chart.yaml
+++ b/charts/she-runtime/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: she-runtime
 description: SHE default K8s cluster toolset
 type: application
-version: 1.4.1
-appVersion: "1.4.1"
+version: 1.4.2
+appVersion: "1.4.2"

--- a/charts/she-runtime/README.md
+++ b/charts/she-runtime/README.md
@@ -1,6 +1,6 @@
 # she-runtime
 
-![Version: 1.4.1](https://img.shields.io/badge/Version-1.4.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.4.1](https://img.shields.io/badge/AppVersion-1.4.1-informational?style=flat-square)
+![Version: 1.4.2](https://img.shields.io/badge/Version-1.4.2-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.4.2](https://img.shields.io/badge/AppVersion-1.4.2-informational?style=flat-square)
 
 SHE default K8s cluster toolset
 
@@ -87,7 +87,7 @@ SHE default K8s cluster toolset
 | opensearchOperator.namespace | string | `"opensearch-operator"` |  |
 | opensearchOperator.source.chart | string | `"opensearch-operator"` |  |
 | opensearchOperator.source.repoURL | string | `"https://opensearch-project.github.io/opensearch-k8s-operator/"` |  |
-| opensearchOperator.source.targetRevision | string | `"2.6.0"` |  |
+| opensearchOperator.source.targetRevision | string | `"2.6.1"` |  |
 | postgresOperator.enabled | bool | `true` |  |
 | postgresOperator.name | string | `"postgres-operator"` |  |
 | postgresOperator.namespace | string | `"postgres-operator"` |  |

--- a/charts/she-runtime/values.yaml
+++ b/charts/she-runtime/values.yaml
@@ -339,7 +339,7 @@ opensearchOperator:
   source:
     repoURL: https://opensearch-project.github.io/opensearch-k8s-operator/
     chart: opensearch-operator
-    targetRevision: 2.6.0
+    targetRevision: 2.6.1
 
 taintController:
   enabled: false


### PR DESCRIPTION
While the ISM problem still seems to persist in v2.6.1 the timestamp field issue from https://github.com/opensearch-project/opensearch-k8s-operator/issues/798 got fixed.