### PR TITLE
Replacing secrettypes block under secretsExporter

### DIFF
--- a/charts/she-runtime/values.yaml
+++ b/charts/she-runtime/values.yaml
@@ -379,11 +379,6 @@ x509Exporter:
     chart: x509-certificate-exporter
     helm:
       values: |
-        secretTypes:
-        - type: kubernetes.io/tls
-          key: tls.crt
-        - type: Opaque
-          key: tls.crt
         prometheusServiceMonitor:
           extraLabels:
             kubernetes.she.net/prometheus-instance: default
@@ -399,3 +394,8 @@ x509Exporter:
             limits:
               cpu: null
               memory: 150M
+            secretTypes:
+            - type: kubernetes.io/tls
+              key: tls.crt
+            - type: Opaque
+              key: tls.crt


### PR DESCRIPTION
According to the [github x509 chart](https://github.com/enix/x509-certificate-exporter/blob/main/deploy/charts/x509-certificate-exporter/values.yaml#L61-L125) the secretType block should be placed under secretExporter block.